### PR TITLE
spec: disable concurrent build

### DIFF
--- a/efitools.spec.in
+++ b/efitools.spec.in
@@ -38,7 +38,7 @@ secure variables of the UEFI firmware, usually in the NVRAM area.
 
 %build
 %set_build_flags
-%make_build
+%make_build -j1
 
 %install
 %make_install DOCDIR=%{buildroot}%{_docdir}/%{name}/ CFLAGS="%{optflags}"


### PR DESCRIPTION
This should prevents from such errors:

> DEBUG: ./cert-to-efi-sig-list PK.crt PK-blacklist.esl
> DEBUG: make: ./cert-to-efi-sig-list: Command not found
> DEBUG: make: *** [Make.rules:75: PK-blacklist.esl] Error 127